### PR TITLE
Window Setup with Event handling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Texel/third-party/spdlog"]
 	path = Texel/third-party/spdlog
 	url = https://github.com/gabime/spdlog.git
+[submodule "Texel/third-party/glfw"]
+	path = Texel/third-party/glfw
+	url = https://github.com/glfw/glfw.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ if (WIN32)
 endif()
 
 
+if(${CMAKE_BUILD_TYPE} MATCHES Debug)
+    target_compile_definitions(${PROJECT} PUBLIC TEXEL_DEBUG TEXEL_ENABLE_ASSERTS)
+elseif(${CMAKE_BUILD_TYPE} MATCHES Release)
+    target_compile_definitions(${PROJECT} PUBLIC TEXEL_RELEASE)
+endif()
+
 if (WIN32)
     add_custom_command(TARGET ${PROJECT} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/Texel/CMakeLists.txt
+++ b/Texel/CMakeLists.txt
@@ -24,21 +24,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE 1)
 add_subdirectory(${THIRD_PARTY_SRCS}/spdlog)
 add_subdirectory(${THIRD_PARTY_SRCS}/glfw)
 
-if (APPLE)
-    list(APPEND OPENGL_LIBS
-            "-framework OpenGL")
-elseif (WIN32)
-    list(APPEND OPENGL_LIBS
-            "-lglu32 - lopengl32")
-    set(CMAKE_EXE_LINDER_FLAGS "-std-gnu99 -static -static-libgcc -static-libstdc++ -mwindows")
-else ()
-    list(APPEND OPENGL_LIBS
-            "-lGL -lGLU -lX11")
-endif ()
+find_package(OpenGL REQUIRED)
 
 add_library(${PROJECT} SHARED ${FILE_SOURCES})
 
-target_link_libraries(${PROJECT} spdlog glfw ${OPENGL_LIBS})
+target_link_libraries(${PROJECT} spdlog glfw ${OPENGL_LIBRARY})
 
 if (WIN32)
     target_compile_definitions(${PROJECT} PRIVATE TEXEL_PLATFORM_WINDOWS TEXEL_BUILD_DLL)

--- a/Texel/CMakeLists.txt
+++ b/Texel/CMakeLists.txt
@@ -34,4 +34,11 @@ if (WIN32)
     target_compile_definitions(${PROJECT} PRIVATE TEXEL_PLATFORM_WINDOWS TEXEL_BUILD_DLL)
 endif()
 
+
+if(${CMAKE_BUILD_TYPE} MATCHES Debug)
+    target_compile_definitions(${PROJECT} PUBLIC TEXEL_DEBUG TEXEL_ENABLE_ASSERTS)
+elseif(${CMAKE_BUILD_TYPE} MATCHES Release)
+    target_compile_definitions(${PROJECT} PUBLIC TEXEL_RELEASE)
+endif()
+
 # target_precompile_headers(${PROJECT} PRIVATE src/texel_pch.h)

--- a/Texel/CMakeLists.txt
+++ b/Texel/CMakeLists.txt
@@ -17,14 +17,28 @@ file(GLOB_RECURSE FILE_SOURCES "${TEXEL_SRCS}/*.h" "${TEXEL_SRCS}/*.cpp")
 
 include_directories(${TEXEL_SRCS})
 include_directories(${THIRD_PARTY_SRCS}/spdlog/include)
+include_directories(${THIRD_PARTY_SRCS}/glfw/include)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE 1)
 
 add_subdirectory(${THIRD_PARTY_SRCS}/spdlog)
+add_subdirectory(${THIRD_PARTY_SRCS}/glfw)
+
+if (APPLE)
+    list(APPEND OPENGL_LIBS
+            "-framework OpenGL")
+elseif (WIN32)
+    list(APPEND OPENGL_LIBS
+            "-lglu32 - lopengl32")
+    set(CMAKE_EXE_LINDER_FLAGS "-std-gnu99 -static -static-libgcc -static-libstdc++ -mwindows")
+else ()
+    list(APPEND OPENGL_LIBS
+            "-lGL -lGLU -lX11")
+endif ()
 
 add_library(${PROJECT} SHARED ${FILE_SOURCES})
 
-target_link_libraries(${PROJECT} spdlog)
+target_link_libraries(${PROJECT} spdlog glfw ${OPENGL_LIBS})
 
 if (WIN32)
     target_compile_definitions(${PROJECT} PRIVATE TEXEL_PLATFORM_WINDOWS TEXEL_BUILD_DLL)

--- a/Texel/src/Platform/Windows/WindowsWindow.cpp
+++ b/Texel/src/Platform/Windows/WindowsWindow.cpp
@@ -1,0 +1,71 @@
+#include "texel_pch.h"
+#include "WindowsWindow.h"
+
+namespace Texel
+{
+    static bool s_GLFWInitialized = false;
+
+    Window *Window::Create(const WindowProps &props)
+    {
+        return new WindowsWindow(props);
+    }
+
+    WindowsWindow::WindowsWindow(const WindowProps &props)
+    {
+        Init(props);
+    }
+
+    WindowsWindow::~WindowsWindow()
+    {
+        Shutdown();
+    }
+
+    void WindowsWindow::Init(const WindowProps &props)
+    {
+        m_Data.Title = props.Title;
+        m_Data.Width = props.Width;
+        m_Data.Height = props.Height;
+
+        TEXEL_CORE_INFO("Creating window {0} ({1}, {2})", props.Title, props.Width, props.Height);
+
+        if (!s_GLFWInitialized)
+        {
+            // TODO: glfwTerminate on system shutdown
+            int success = glfwInit();
+            TEXEL_CORE_ASSERT(success, "Could not intialize GLFW!");
+
+            s_GLFWInitialized = true;
+        }
+
+        m_Window = glfwCreateWindow((int)props.Width, (int)props.Height, m_Data.Title.c_str(), nullptr, nullptr);
+        glfwMakeContextCurrent(m_Window);
+        glfwSetWindowUserPointer (m_Window, &m_Data);
+        SetVSync(true);
+    }
+
+    void WindowsWindow::Shutdown()
+    {
+        glfwDestroyWindow(m_Window);
+    }
+
+    void WindowsWindow::OnUpdate()
+    {
+        glfwPollEvents();
+        glfwSwapBuffers(m_Window);
+    }
+
+    void WindowsWindow::SetVSync(bool enabled)
+    {
+        if (enabled)
+            glfwSwapInterval(1);
+        else
+            glfwSwapInterval(0);
+
+        m_Data.VSync = enabled;
+    }
+
+    bool WindowsWindow::IsVSync() const
+    {
+        return m_Data.VSync;
+    }
+} // namespace Texel

--- a/Texel/src/Platform/Windows/WindowsWindow.h
+++ b/Texel/src/Platform/Windows/WindowsWindow.h
@@ -26,6 +26,8 @@ namespace Texel
         virtual void Init(const WindowProps &props);
         virtual void Shutdown();
 
+        void RegisterEvents();
+
     private:
         GLFWwindow *m_Window;
 

--- a/Texel/src/Platform/Windows/WindowsWindow.h
+++ b/Texel/src/Platform/Windows/WindowsWindow.h
@@ -1,0 +1,46 @@
+#ifndef WINDOWS_WINDOW_H
+#define WINDOWS_WINDOW_H
+
+#include "Texel/Window.h"
+#include "GLFW/glfw3.h"
+
+namespace Texel
+{
+    class WindowsWindow : public Window
+    {
+    public:
+        WindowsWindow(const WindowProps &props);
+        virtual ~WindowsWindow();
+
+        void OnUpdate() override;
+
+        inline unsigned int GetWidth() const override { return m_Data.Width; }
+        inline unsigned int GetHeight() const override { return m_Data.Height; }
+
+        // Window attributes
+        inline void SetEventCallback(const EventCallbackFn &callback) override { m_Data.EventCallback = callback; }
+        void SetVSync(bool enabled) override;
+        bool IsVSync() const override;
+
+    private:
+        virtual void Init(const WindowProps &props);
+        virtual void Shutdown();
+
+    private:
+        GLFWwindow *m_Window;
+
+        struct WindowData
+        {
+            std::string Title;
+            unsigned int Width, Height;
+            bool VSync;
+
+            EventCallbackFn EventCallback;
+        };
+
+        WindowData m_Data;
+    };
+
+} // namespace Texel
+
+#endif

--- a/Texel/src/Texel/Application.cpp
+++ b/Texel/src/Texel/Application.cpp
@@ -7,9 +7,20 @@
 
 namespace Texel
 {
+
+#define BIND_EVENT_FN(x) std::bind(&x, this, std::placeholders::_1)
+
     Application::Application()
     {
         m_Window = std::unique_ptr<Window>(Window::Create());
+        m_Window->SetEventCallback(BIND_EVENT_FN(Application::OnEvent));
+    }
+
+    void Application::OnEvent(Event &e)
+    {
+        TEXEL_CORE_INFO("{0}", e);
+        EventDispatcher dispatcher(e);
+        dispatcher.Dispatch<WindowCloseEvent>(BIND_EVENT_FN(Application::OnWindowClose));
     }
 
     Application::~Application() {}
@@ -22,4 +33,11 @@ namespace Texel
          }
          
     }
+
+    bool Application::OnWindowClose(WindowCloseEvent &event)
+    {
+        m_Running = false;
+        return true;
+    }
+
 } // namespace Texel

--- a/Texel/src/Texel/Application.cpp
+++ b/Texel/src/Texel/Application.cpp
@@ -1,6 +1,7 @@
 #include "texel_pch.h"
 #include "Application.h"
 
+#include <GLFW/glfw3.h>
 #include "Texel/Events/ApplicationEvent.h"
 #include "Texel/Log.h"
 
@@ -21,7 +22,22 @@ namespace Texel
         {
             TEXEL_TRACE(e);
         }
+
+        if (!glfwInit()) {
+            TEXEL_CORE_ERROR("Unable to init GLFW");
+            return;
+        }
+        auto window = glfwCreateWindow(1280, 720, "TexelApp", nullptr, nullptr);
+        glfwMakeContextCurrent(window);
         
-        while (true);
+        while (!glfwWindowShouldClose(window)) {
+            glClear(GL_COLOR_BUFFER_BIT);
+
+            glfwSwapBuffers(window);
+
+            glfwPollEvents();
+        }
+        glfwDestroyWindow(window);
+        glfwTerminate();
     }
 } // namespace Texel

--- a/Texel/src/Texel/Application.cpp
+++ b/Texel/src/Texel/Application.cpp
@@ -7,37 +7,19 @@
 
 namespace Texel
 {
-    Application::Application() {}
+    Application::Application()
+    {
+        m_Window = std::unique_ptr<Window>(Window::Create());
+    }
 
     Application::~Application() {}
 
     void Application::Run()
     {
-        WindowResizeEvent e(1280, 720);
-        if (e.IsInCategory(EventCategoryApplication))
-        {
-            TEXEL_TRACE(e);
-        }
-        if (e.IsInCategory(EventCategoryInput))
-        {
-            TEXEL_TRACE(e);
-        }
-
-        if (!glfwInit()) {
-            TEXEL_CORE_ERROR("Unable to init GLFW");
-            return;
-        }
-        auto window = glfwCreateWindow(1280, 720, "TexelApp", nullptr, nullptr);
-        glfwMakeContextCurrent(window);
-        
-        while (!glfwWindowShouldClose(window)) {
-            glClear(GL_COLOR_BUFFER_BIT);
-
-            glfwSwapBuffers(window);
-
-            glfwPollEvents();
-        }
-        glfwDestroyWindow(window);
-        glfwTerminate();
+         while (m_Running)
+         {
+            m_Window->OnUpdate();
+         }
+         
     }
 } // namespace Texel

--- a/Texel/src/Texel/Application.h
+++ b/Texel/src/Texel/Application.h
@@ -3,6 +3,7 @@
 
 #include "Core.h"
 #include "Events/Event.h"
+#include "Window.h"
 
 namespace Texel {
     class TEXEL_API Application
@@ -12,6 +13,10 @@ namespace Texel {
         virtual ~Application();
 
         void Run();
+
+    private:
+        std::unique_ptr<Window> m_Window;
+        bool m_Running = true;
     };
     
     // To be defined in Client

--- a/Texel/src/Texel/Application.h
+++ b/Texel/src/Texel/Application.h
@@ -2,8 +2,9 @@
 #define Application_h
 
 #include "Core.h"
-#include "Events/Event.h"
 #include "Window.h"
+#include "Events/Event.h"
+#include "Events/ApplicationEvent.h"
 
 namespace Texel {
     class TEXEL_API Application
@@ -14,7 +15,11 @@ namespace Texel {
 
         void Run();
 
+        void OnEvent(Event &event);
+
     private:
+        bool OnWindowClose(WindowCloseEvent &e);
+
         std::unique_ptr<Window> m_Window;
         bool m_Running = true;
     };

--- a/Texel/src/Texel/Log.h
+++ b/Texel/src/Texel/Log.h
@@ -35,4 +35,12 @@ namespace Texel
 #define TEXEL_ERROR(...)        ::Texel::Log::GetClientLogger()->error(__VA_ARGS__)
 #define TEXEL_FATAL(...)        ::Texel::Log::GetClientLogger()->fatal(__VA_ARGS__)
 
+#ifdef TEXEL_ENABLE_ASSERTS
+	#define TEXEL_ASSERT(x, ...) { if(!(x)) { TEXEL_ERROR("Assertion Failed: {0}", __VA_ARGS__); } }
+	#define TEXEL_CORE_ASSERT(x, ...) { if(!(x)) { TEXEL_CORE_ERROR("Assertion Failed: {0}", __VA_ARGS__); } }
+#else
+	#define TEXEL_ASSERT(x, ...)
+	#define TEXEL_CORE_ASSERT(x, ...)
+#endif
+
 #endif

--- a/Texel/src/Texel/Window.h
+++ b/Texel/src/Texel/Window.h
@@ -1,0 +1,46 @@
+#ifndef Window_h
+#define Window_h
+
+#include "texel_pch.h"
+
+#include "Texel/Core.h"
+#include "Texel/Events/Event.h"
+
+namespace Texel
+{
+    struct WindowProps
+    {
+        std::string Title;
+        unsigned int Width;
+        unsigned int Height;
+
+        WindowProps(
+            const std::string &title = "Texel Engine",
+            const unsigned int &width = 1280,
+            const unsigned int &height = 720) : Title(title), Width(width), Height(height) {}
+    };
+
+    // Interface representing a desktop system based Window
+    class TEXEL_API Window
+    {
+    public:
+        using EventCallbackFn = std::function<void(Event &)>;
+
+        virtual ~Window() = default;
+
+        virtual void OnUpdate() = 0;
+
+        virtual unsigned int GetWidth() const = 0;
+        virtual unsigned int GetHeight() const = 0;
+
+        // Window attributes
+        virtual void SetEventCallback(const EventCallbackFn &callback) = 0;
+        virtual void SetVSync(bool enabled) = 0;
+        virtual bool IsVSync() const = 0;
+
+        static Window *Create(const WindowProps &props = WindowProps());
+    };
+
+} // namespace Texel
+
+#endif

--- a/Texel/src/texel_pch.h
+++ b/Texel/src/texel_pch.h
@@ -1,6 +1,8 @@
 #ifndef Texel_Pch_h // precompilied headers
 #define Texel_Pch_h
 
+#include "Texel/Log.h"
+
 #include <iostream>
 #include <memory>
 #include <utility>


### PR DESCRIPTION
1. Integrated Glow library in make for creating windows
2. Added window interface inside `Window.h`. This abstraction is platform independent.
3. Implemented `WindowsWindow.h` from `Window.h` for windows platform.
4. Added different callbacks to listen for window resize, key press, mouse scroll, mouse move, etc.
5. Completed with Event dispatcher to dispatch WindowCloseEvent and close the application.